### PR TITLE
Add pycurl in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
+pycurl --install-option="--with-nss"
 urlgrabber


### PR DESCRIPTION
urlgrabber requires pycurl to be installed
